### PR TITLE
Move Config file to .config/livefs/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ all: $(ELF_TARGET_64)
 $(ELF_TARGET_64): $(ELF_OBJS_64)
 	@mkdir -p $(ELF_BIN_DIR_64)
 	$(CC) $(COMMON_CFLAGS) $(CFLAGS) -m64 -o $(ELF_BIN_DIR_64)/$(ELF_TARGET_64) $^
-	cp config.cfg $(ELF_BIN_DIR_64)
 #
 # Object build rules per architecture
 #

--- a/include/config/config_file.h
+++ b/include/config/config_file.h
@@ -16,7 +16,7 @@
 /// @brief gets the config file from disk
 /// @param working_path current working directory
 /// @return FILE config
-char *get_config_file(const char *working_path);
+char *get_config_file(char *buf);
 
 /// @brief Gets the value related to a key from the configuration file
 /// @param config_file config file context

--- a/include/utils/path.h
+++ b/include/utils/path.h
@@ -4,5 +4,5 @@
 #include <utils/terminal.h>
 #include <linux/limits.h>
 
-char *get_current_working_path(void);
+char *get_current_exec_path(void);
 char *get_home_path(void);

--- a/include/utils/path.h
+++ b/include/utils/path.h
@@ -4,4 +4,5 @@
 #include <utils/terminal.h>
 #include <linux/limits.h>
 
-const char *get_current_working_path(char *buf, size_t buf_size);
+char *get_current_working_path(void);
+char *get_home_path(void);

--- a/src/config/config_file.c
+++ b/src/config/config_file.c
@@ -10,18 +10,30 @@ char *get_config_file(char *buf) {
     // if there is a config file in the same directory as the executable, we will piroritise it
     strcpy(config_file_path, get_current_exec_path());
     strcat(config_file_path, config_file);
-    FILE *fp = fopen(config_file_path, "rb");
-    if (fp) {
-        size_t read_config = fread(buf, 1, PATH_MAX - 1, fp);
-        fclose(fp);
-        buf[read_config] = '\0';
+    FILE *fp;
+    fp = fopen(config_file_path, "rb");
 
-        char *trimmed_config = trim_whitespaces(buf);
-        if (trimmed_config != buf){
-            memmove(buf, trimmed_config, strlen(trimmed_config) + 1);
+    if (!fp) {
+        // now we check if its in .config/
+        memset(config_file_path, 0, strlen(config_file_path));
+        strcpy(config_file_path, get_home_path());
+        strcat(config_file_path, "/.config/livefs");
+        strcat(config_file_path, config_file);
+        fp = fopen(config_file_path, "rb");
+        if (!fp) {
+            fprintf(stderr, FATAL "No Config file found!\n");
+            exit(-1);
         }
-
-        return buf;
     }
-    return "\0";
+    
+    size_t read_config = fread(buf, 1, PATH_MAX - 1, fp);
+    fclose(fp);
+    buf[read_config] = '\0';
+
+    char *trimmed_config = trim_whitespaces(buf);
+    if (trimmed_config != buf){
+        memmove(buf, trimmed_config, strlen(trimmed_config) + 1);
+    }
+
+    return buf;
 }

--- a/src/config/config_file.c
+++ b/src/config/config_file.c
@@ -8,7 +8,7 @@ char *get_config_file(char *buf) {
     char config_file_path[PATH_MAX];
 
     // if there is a config file in the same directory as the executable, we will piroritise it
-    strcpy(config_file_path, get_current_working_path());
+    strcpy(config_file_path, get_current_exec_path());
     strcat(config_file_path, config_file);
     FILE *fp = fopen(config_file_path, "rb");
     if (fp) {

--- a/src/config/config_file.c
+++ b/src/config/config_file.c
@@ -1,56 +1,27 @@
 #include <config/config_file.h>
-
-char *cached_config_file = NULL;
+#include <utils/path.h>
 
 /// @brief gets the config file from disk
-/// @param working_path current working directory
 /// @return FILE config
-char *get_config_file(const char *working_path) {
-    if (cached_config_file) return cached_config_file;
+char *get_config_file(char *buf) {
+    char *config_file = "/config.cfg";
+    char config_file_path[PATH_MAX];
 
-    // new config path buffer to not tamper with the other one, also we add a null terminator.
-    char config_path[PATH_MAX];
-    strncpy(config_path, working_path, sizeof(config_path) - 1);
-    config_path[sizeof(config_path) - 1] = '\0';
-
-    // ensure we end in a / so that we can just append filename without worrying about leading /'s
-    size_t len = strlen(config_path);
-    if (len > 0 && config_path[len - 1] != '/') {
-        strncat(config_path, "/", sizeof(config_path) - strlen(config_path) - 1);
-    }
-
-    // concatonate the config file name and then check if it actually exsists
-    strncat(config_path, "config.cfg", sizeof(config_path) - strlen(config_path) - 1);
-    FILE *fp = fopen(config_path, "rb");
-    if (!fp) {
-        //TODO: maybe implement config file rebuilding here?
-        fprintf(stderr, "%s Failed to open config file (%s).\n", ERROR, config_path);
-        perror("fopen");
-        return NULL;
-    }
-
-    fseek(fp, 0L, SEEK_END);
-    size_t filesize = ftell(fp);
-    fseek(fp, 0L, SEEK_SET);
-
-    char *untrimmed_config = malloc(filesize + 1);
-    if (!untrimmed_config){
+    // if there is a config file in the same directory as the executable, we will piroritise it
+    strcpy(config_file_path, get_current_working_path());
+    strcat(config_file_path, config_file);
+    FILE *fp = fopen(config_file_path, "rb");
+    if (fp) {
+        size_t read_config = fread(buf, 1, PATH_MAX - 1, fp);
         fclose(fp);
-        return NULL;
-    }
+        buf[read_config] = '\0';
 
-    size_t read_size = fread(untrimmed_config, 1, filesize, fp);
-    fclose(fp);
-    if (read_size != filesize){
-        fprintf(stderr, ERROR "Shortread :( %zu/%zu bytes\n", read_size, filesize);
-        free(untrimmed_config);
-        untrimmed_config = NULL;
-        return NULL;
-    }
+        char *trimmed_config = trim_whitespaces(buf);
+        if (trimmed_config != buf){
+            memmove(buf, trimmed_config, strlen(trimmed_config) + 1);
+        }
 
-    // finally add null term
-    untrimmed_config[filesize] = '\0';
-    cached_config_file = malloc(strlen(trim_whitespaces(untrimmed_config)));
-    cached_config_file = trim_whitespaces(untrimmed_config);  // do us a favour and trim the whitespace
-    return cached_config_file;
+        return buf;
+    }
+    return "\0";
 }

--- a/src/config/config_keys.c
+++ b/src/config/config_keys.c
@@ -22,7 +22,7 @@ char *find_key_in_config(char *pattern, const char *config_file, const char *key
     char *pos = strstr(config_file, pattern);
     if (!pos) {
         fprintf(stderr, ERROR "Config key not found: %s\n", key);
-        return NULL;
+        exit(-1);
     }
 
     return pos;

--- a/src/fs/filepath.c
+++ b/src/fs/filepath.c
@@ -27,7 +27,7 @@ int path_exsists(const char *path){
 void build_file_path(char *buf, size_t buf_size, const char *filename){
 
     char *working_directory;
-    working_directory = get_current_working_path();
+    working_directory = get_current_exec_path();
 
     char *config_file = get_config_file(working_directory);
     char totalpath[PATH_MAX];
@@ -57,7 +57,7 @@ void build_file_path(char *buf, size_t buf_size, const char *filename){
 void get_root_path(char *buf, size_t buf_size, const char *filename){
 
     char *working_directory;
-    working_directory = get_current_working_path();
+    working_directory = get_current_exec_path();
 
     char *config_file = get_config_file(working_directory);
     char totalpath[PATH_MAX];

--- a/src/fs/filepath.c
+++ b/src/fs/filepath.c
@@ -26,8 +26,8 @@ int path_exsists(const char *path){
 /// @param filename target filename
 void build_file_path(char *buf, size_t buf_size, const char *filename){
 
-    char working_directory[PATH_MAX];
-    get_current_working_path(working_directory, PATH_MAX);
+    char *working_directory;
+    working_directory = get_current_working_path();
 
     char *config_file = get_config_file(working_directory);
     char totalpath[PATH_MAX];
@@ -40,7 +40,6 @@ void build_file_path(char *buf, size_t buf_size, const char *filename){
     if (totalpath[0] == '~') {
         const char *home = getenv("HOME");
         if (!home) home = "";
-
         snprintf(buf, buf_size, "%s%s", home, totalpath + 1);
     } else {
         strncpy(buf, totalpath, buf_size - 1);
@@ -57,8 +56,8 @@ void build_file_path(char *buf, size_t buf_size, const char *filename){
 
 void get_root_path(char *buf, size_t buf_size, const char *filename){
 
-    char working_directory[PATH_MAX];
-    get_current_working_path(working_directory, PATH_MAX);
+    char *working_directory;
+    working_directory = get_current_working_path();
 
     char *config_file = get_config_file(working_directory);
     char totalpath[PATH_MAX];

--- a/src/main.c
+++ b/src/main.c
@@ -8,11 +8,9 @@
 int server_socket = 0;
 
 int main(int argc, const char *argv[]){
-    char working_directory[PATH_MAX];
-    get_current_working_path(working_directory, PATH_MAX);
-
-    char *config_file = get_config_file(working_directory);
-    if (!config_file){
+    char config_file_path[PATH_MAX];
+    get_config_file(config_file_path);
+    if (config_file_path[0] == '\0'){
         printf(FATAL "No Config File Found!\n");
         return -1;
     }
@@ -22,7 +20,7 @@ int main(int argc, const char *argv[]){
     get_root_path(root_path, sizeof(root_path));
     path_exsists(root_path);
 
-    int srvport = config_get_int(config_file, "port");
+    int srvport = config_get_int(config_file_path, "port");
     server_socket = server_create_socket(server_socket);
 
     server_bind_socket(srvport, server_socket);
@@ -31,5 +29,4 @@ int main(int argc, const char *argv[]){
 
     // Clean up, at this point the server is closed
     close(server_socket);
-    free(config_file);
 }

--- a/src/utils/path.c
+++ b/src/utils/path.c
@@ -3,24 +3,52 @@
 #include <utils/terminal.h>
 #include <linux/limits.h>
 #include <string.h>
+#include <stdlib.h>
 
 /// @brief gets the parent path of the current working directory.
 /// @param buf dest buffer
 /// @param buf_size dest buffer size
 /// @return path
-const char *get_current_working_path(char *buf, size_t buf_size){
-    ssize_t len = readlink("/proc/self/exe", buf, buf_size - 1);
+char *get_current_working_path(void){
+    static char path_buffer[PATH_MAX];
+    if (path_buffer == NULL) return path_buffer;
+
+    ssize_t len = readlink("/proc/self/exe", path_buffer, PATH_MAX - 1);
     if (len == -1) {
         fprintf(stderr, ERROR "failed to get executable path\n");
         return NULL;
     }
-    buf[len] = '\0'; // null terminate
+    path_buffer[len] = '\0'; // null terminate
 
     // strip off the filename to get the parent directory
-    char *last_slash = strrchr(buf, '/');
+    char *last_slash = strrchr(path_buffer, '/');
     if (last_slash != NULL) {
         *last_slash = '\0'; // truncate at the last '/'
     }
+    
+    return path_buffer;
+}
 
-    return buf;
+/// @brief returns the home path of the current user
+/// @return path
+const char *get_home_path(void){
+    static char *cached_home_path = NULL;
+    if (cached_home_path != NULL) return cached_home_path;
+
+    char *home = getenv("HOME");
+    if (home == NULL){
+        // we have to check for this and then return as we are about
+        // to add a '/', so if this value is empty it will be just '/' a.k.a
+        // root, potentially exposing the servers root directory!
+        return NULL;
+    }
+
+    size_t len = strlen(home);
+    if (len + 1 < sizeof(home)){
+        home[len] = '/';
+        home[len+1] = '\0';
+    }
+
+    cached_home_path = home;
+    return cached_home_path;
 }

--- a/src/utils/path.c
+++ b/src/utils/path.c
@@ -7,25 +7,22 @@
 
 /// @brief gets the parent path of the current working directory.
 /// @param buf dest buffer
-/// @param buf_size dest buffer size
 /// @return path
-char *get_current_exec_path(void){
-    char path_buffer[PATH_MAX];
-
-    ssize_t len = readlink("/proc/self/exe", path_buffer, PATH_MAX - 1);
+char *get_current_exec_path(char *buf){
+    ssize_t len = readlink("/proc/self/exe", buf, PATH_MAX - 1);
     if (len == -1) {
         fprintf(stderr, ERROR "failed to get executable path\n");
         return NULL;
     }
-    path_buffer[len] = '\0'; // null terminate
+    buf[len] = '\0'; // null terminate
 
     // strip off the filename to get the parent directory
-    char *last_slash = strrchr(path_buffer, '/');
+    char *last_slash = strrchr(buf, '/');
     if (last_slash != NULL) {
         *last_slash = '\0'; // truncate at the last '/'
     }
-    
-    return path_buffer;
+
+    return buf;
 }
 
 /// @brief returns the home path of the current user

--- a/src/utils/path.c
+++ b/src/utils/path.c
@@ -9,9 +9,8 @@
 /// @param buf dest buffer
 /// @param buf_size dest buffer size
 /// @return path
-char *get_current_working_path(void){
-    static char path_buffer[PATH_MAX];
-    if (path_buffer == NULL) return path_buffer;
+char *get_current_exec_path(void){
+    char path_buffer[PATH_MAX];
 
     ssize_t len = readlink("/proc/self/exe", path_buffer, PATH_MAX - 1);
     if (len == -1) {


### PR DESCRIPTION
It seems reasonable to move the configuration file to .config/livefs as this is standard for a lot of software and the folder exists for a reason.

The program will first check if there is a config file within the directory the executable is in, I would half expect this to fail but this is more of an "override" than anything else.
if this fails, it will then check ~/.config/livefs/ for a `config.cfg` file. if this fails.
if all above fails, we just exit.

if at any point a valid config is found it will pass it.