### PR TITLE
fix for "too many arguments to function" compile time error

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -61,7 +61,7 @@ int main(int argc, const char *argv[]){
     gtinit();
 
     int srvport = config_get_int(config_file, "port");
-    server_socket = server_create_socket(server_socket);
+    server_socket = server_create_socket();
     
     free(config_file);
 

--- a/src/socket/server.c
+++ b/src/socket/server.c
@@ -15,23 +15,24 @@ struct sockaddr_in get_server_sockaddr(){
 
 /// @brief Creates the Server Socket (socket() wrapper)
 /// @return 'int' server socket
-int server_create_socket(int server_socket){
+int server_create_socket() {
     int opt = 1;
-    server_socket = socket(AF_INET, SOCK_STREAM, 0);
-    
-    if (server_socket == -1){
-        fprintf(stderr, FATAL "Error in Creating Socket, Socket Return -1 %s:%d\n", __FILE__, __LINE__);
-        exit(-1);
-    }else{
-        if(setsockopt(server_socket, SOL_SOCKET, SO_REUSEADDR, (void*)&opt, sizeof(opt)) < 0) {
-            perror("setsockopt");
-            fprintf(stderr, FATAL "Could not set SO_REUSEADDR");
-            close(server_socket);
-            return 1;
-        }
+    int server_socket;
 
-        return server_socket;
+    server_socket = socket(AF_INET, SOCK_STREAM, 0);
+    if (server_socket == -1) {
+        fprintf(stderr, FATAL "Error creating socket: %s:%d\n", __FILE__, __LINE__);
+        exit(-1);
     }
+
+    if (setsockopt(server_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
+        perror("setsockopt");
+        fprintf(stderr, FATAL "Could not set SO_REUSEADDR\n");
+        close(server_socket);
+        exit(-1); // fail immediately
+    }
+
+    return server_socket;
 }
 
 /// @brief Binds the socket to a port and address, address is set to INADDR_ANY. handle cleanup if failed


### PR DESCRIPTION
fixes the following error (note: fix may require additional testing as my current setup is not suitable)

src/main.c:64:21: error: too many arguments to function ‘server_create_socket’; expected 0, have 1
   64 |     server_socket = server_create_socket(server_socket);
      |                     ^~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~
In file included from src/main.c:7:
include/socket/socket.h:12:5: note: declared here
   12 | int server_create_socket();
      |     ^~~~~~~~~~~~~~~~~~~~
make: *** [Makefile:61: bin/elf/64/obj/main.gcc.o] Error 1